### PR TITLE
Add workflow for automatic releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,37 @@
+on:
+  push:
+    tags:
+    - 'v*'
+
+name: Create Release
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Build project
+        run: |
+          zip -r release.zip . -x "*.git*"
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./release.zip
+          asset_name: release.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
This PR changes / adds / introduces the feature of ....
automatically creating a release containing the zipped repository (without git-files) of the master branch whenever one pushes to a tag starting with 'v'

Testing steps:
- Create a commit.
- Do `git tag v1.0.0`  (or use any other version number)
- Do `git push origin v1.0.0` (using the same version number)
- Check whether a release was created and whether it contains a .zip containing all relevant files

Acceptance Criteria:
- Release shall be created automatically on push
- Release name shall contain the version number
- Release shall contain master repository without git-files

Solves tech problem, so I'd say issue #4 or #5 

Steps needed for migration:
- no special steps needed
