### PR TITLE
Add node_modules to rubocop ignore

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ AllCops:
     - '**/tmp/**/*'
     - '**/vendor/**/*'
     - '**/bin/**/*'
+    - 'node_modules/**/*'
 
 # Prefer assert_not over assert !
 Rails/AssertNot:


### PR DESCRIPTION
This PR adds the node_modules to the .rubocop.yml exclusions.