### PR TITLE
Implement #38.

### DIFF
--- a/app/controllers/lectures_controller.rb
+++ b/app/controllers/lectures_controller.rb
@@ -57,6 +57,15 @@ class LecturesController < ApplicationController
     lecture.set_active
     lecture.save
     redirect_to lecture_path(lecture)
+    end
+
+  def end_lecture
+    # TODO make sure user is lecturer
+    id = params["lecture"]
+    lecture = Lecture.find(id)
+    lecture.set_inactive
+    lecture.save
+    redirect_to lecture_path(lecture)
   end
 
   private

--- a/app/models/lecture.rb
+++ b/app/models/lecture.rb
@@ -8,4 +8,8 @@ class Lecture < ApplicationRecord
   def set_active
     self.is_running=true
   end
+
+  def set_inactive
+    self.is_running=false
+  end
 end

--- a/app/views/lectures/show.html.erb
+++ b/app/views/lectures/show.html.erb
@@ -14,9 +14,12 @@
   <strong>Is running:</strong>
   <%= @lecture.is_running %>
 </p>
-
-<%= link_to 'Edit', edit_lecture_path(@lecture) %> |
-<%= link_to 'Back', lectures_path %>
-<% if @lecture.is_running %>
-  <%= button_to "End", {action: "end_lecture", params: {lecture: @lecture.id}}, {class:"btn btn-link"} %>
-<%end %>
+<table>
+  <tr>
+    <td colspan="2"><%= link_to 'Edit', edit_lecture_path(@lecture), {class:"btn btn-link"} %> | </td>
+    <td colspan="2"><%= link_to 'Back', lectures_path, {class:"btn btn-link"} %> | </td>
+    <% if @lecture.is_running %>
+      <td colspan="2"><%= button_to "End", {action: "end_lecture", params: {lecture: @lecture.id}}, {class:"btn btn-link"} %> </td>
+    <%end %>
+  </tr>
+</table>

--- a/app/views/lectures/show.html.erb
+++ b/app/views/lectures/show.html.erb
@@ -17,3 +17,6 @@
 
 <%= link_to 'Edit', edit_lecture_path(@lecture) %> |
 <%= link_to 'Back', lectures_path %>
+<% if @lecture.is_running %>
+  <%= button_to "End", {action: "end_lecture", params: {lecture: @lecture.id}}, {class:"btn btn-link"} %>
+<%end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   get "/lectures/current", to: "lectures#current", as: "current_lectures"
   post "/lectures/start_lecture", to: "lectures#start_lecture", as: "start_lecture"
+  post "/lectures/end_lecture", to: "lectures#end_lecture", as: "end_lecture"
   resources :lectures
   devise_for :users
   resources :polls

--- a/spec/features/lectures/show_lecture_spec.rb
+++ b/spec/features/lectures/show_lecture_spec.rb
@@ -2,17 +2,17 @@ require "rails_helper"
 
 describe "The show lecture page", type: :feature do
   it "should have no end button if the lecture is not running" do
-      @lecture = FactoryBot.create(:lecture)
-      @lecture.update(is_running: false)
-      visit(lecture_path(@lecture))
-      expect(page).not_to have_selector("input[type=submit][value='End']")
+        @lecture = FactoryBot.create(:lecture)
+        @lecture.update(is_running: false)
+        visit(lecture_path(@lecture))
+        expect(page).not_to have_selector("input[type=submit][value='End']")
       end
 
 
   it "should have an end button if the lecture is running" do
-      @lecture = FactoryBot.create(:lecture)
-      visit(lecture_path(@lecture))
-      expect(page).to have_selector("input[type=submit][value='End']")
+        @lecture = FactoryBot.create(:lecture)
+        visit(lecture_path(@lecture))
+        expect(page).to have_selector("input[type=submit][value='End']")
       end
 
   it "should end the lecture if the end button is clicked" do

--- a/spec/features/lectures/show_lecture_spec.rb
+++ b/spec/features/lectures/show_lecture_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe "The show lecture page", type: :feature do
+  it "should have no end button if the lecture is not running" do
+      @lecture = FactoryBot.create(:lecture)
+      @lecture.update(is_running: false)
+      visit(lecture_path(@lecture))
+      expect(page).not_to have_selector("input[type=submit][value='End']")
+      end
+
+
+  it "should have an end button if the lecture is running" do
+      @lecture = FactoryBot.create(:lecture)
+      visit(lecture_path(@lecture))
+      expect(page).to have_selector("input[type=submit][value='End']")
+      end
+
+  it "should end the lecture if the end button is clicked" do
+      @lecture = FactoryBot.create(:lecture)
+      visit(lecture_path(@lecture))
+      click_on("End")
+      @lecture.reload
+      expect(@lecture.is_running).to be(false)
+    end
+end


### PR DESCRIPTION
This PR changes / adds / introduces the feature of ending lectures

Testing steps:
- start a lecture
- go to the lecture dashboard
- click and
- lecture is not in current lectures

Acceptance Criteria:
Clicking on "end lecture" in the lecture view / dashboard ends the lecture

Ending a lecture removes it from the list of currently active lectures in the student view and removes the option "view" from the lecturers list of lectures

Solves issue #38.

Steps needed for migration:
- run database migration

Screenshot
![image](https://user-images.githubusercontent.com/25150562/69883018-962a2d00-12d2-11ea-98f0-84e98d25e1f5.png)
