### PR TITLE
Add votes attribut to poll options db schema

### DIFF
--- a/app/models/poll_option.rb
+++ b/app/models/poll_option.rb
@@ -1,4 +1,5 @@
 class PollOption < ApplicationRecord
   belongs_to :poll
   validates :description, presence: true, allow_blank: true
+  validates :votes, numericality: { only_integer: true }
 end

--- a/db/migrate/20191206144904_add_votes_to_poll_option.rb
+++ b/db/migrate/20191206144904_add_votes_to_poll_option.rb
@@ -1,0 +1,5 @@
+class AddVotesToPollOption < ActiveRecord::Migration[5.2]
+  def change
+    add_column :poll_options, :votes, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_04_101435) do
+ActiveRecord::Schema.define(version: 2019_12_06_144904) do
 
   create_table "feedbacks", force: :cascade do |t|
     t.text "content"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2019_12_04_101435) do
     t.integer "poll_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "votes", default: 0, null: false
     t.index ["poll_id"], name: "index_poll_options_on_poll_id"
   end
 


### PR DESCRIPTION
This PR adds the integer attribute `votes` to `pollOptions` to save the number of votes this option has received.

Steps needed for migration:
- db migrate
- ...

Definition Of Done:
- [ x] [ER-diagram](https://www.lucidchart.com/invitations/accept/66a4c292-9531-4468-ba60-2a99395ffce4) updated

