### PR TITLE
Link class diagram instead of ERD in Pull Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,5 +21,5 @@ Steps needed for migration:
 ---
 
 Definition Of Done:
-- [ ] [Class-Diagram](https://www.lucidchart.com/documents/edit/683c773b-0912-4055-9540-6a41bf6b06e7/0_0?shared=true) updated
+- [ ] [Class-Diagram](https://www.lucidchart.com/invitations/accept/705a122b-58a9-4dfa-8b16-c936bc0a46bc) updated
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,5 +21,5 @@ Steps needed for migration:
 ---
 
 Definition Of Done:
-- [ ] [ER-diagram](https://www.lucidchart.com/invitations/accept/66a4c292-9531-4468-ba60-2a99395ffce4) updated
+- [ ] [Class-Diagram](https://www.lucidchart.com/documents/edit/683c773b-0912-4055-9540-6a41bf6b06e7/0_0?shared=true) updated
 


### PR DESCRIPTION
# Resolves #number

This PR changes the link in the pull template to a link to the class diagram

Acceptance Criteria:
- [ ] clicking on the link will redirect to Lucidchard with class diagram open


Steps needed for migration:
none

---

Definition Of Done:
- [ ] [ER-diagram](https://www.lucidchart.com/invitations/accept/66a4c292-9531-4468-ba60-2a99395ffce4) updated

