### PR TITLE
redirect after login

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,11 @@
 class HomeController < ApplicationController
   def index
+    if current_user
+      if current_user.is_student
+        redirect_to current_lectures_url
+      else
+        redirect_to lectures_url
+      end
+    end
   end
 end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -2,9 +2,21 @@ require 'rails_helper'
 
 RSpec.describe HomeController, type: :controller do
   describe "GET #index" do
-    it "returns http success" do
+    it "returns http success when no user is logged in" do
       get :index
       expect(response).to have_http_status(:success)
+    end
+
+    it "redirects lecturer to lecture overview" do
+      sign_in(FactoryBot.create(:user, :lecturer), scope: :user)
+      get :index
+      expect(response).to redirect_to(lectures_url)
+    end
+
+    it "redirects lecturer to currently active lectures overview" do
+      sign_in(FactoryBot.create(:user, :student), scope: :user)
+      get :index
+      expect(response).to redirect_to(current_lectures_url)
     end
   end
 end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe HomeController, type: :controller do
       expect(response).to redirect_to(lectures_url)
     end
 
-    it "redirects lecturer to currently active lectures overview" do
+    it "redirects student to currently active lectures overview" do
       sign_in(FactoryBot.create(:user, :student), scope: :user)
       get :index
       expect(response).to redirect_to(current_lectures_url)


### PR DESCRIPTION
I was annoyed to see the sign in page after signing in. This redirects to the correct pages if logged in

---

Definition Of Done:
- [x] ~[Class-Diagram](https://www.lucidchart.com/invitations/accept/705a122b-58a9-4dfa-8b16-c936bc0a46bc) updated~ nothing to change