### PR TITLE
Feature/#167 rejoin entered lecture

### DIFF
--- a/app/controllers/lectures_controller.rb
+++ b/app/controllers/lectures_controller.rb
@@ -50,6 +50,11 @@ class LecturesController < ApplicationController
 
   # PATCH/PUT courses/:course_id/lectures/1
   def update
+    if !@lecture.enrollment_key && lecture_params[:enrollment_key]
+      @lecture.participating_students.each do | student |
+        @lecture.leave_lecture(student)
+      end
+    end
     if @lecture.update(lecture_params)
       redirect_to course_lecture_path(@course, @lecture), notice: "Lecture was successfully updated."
     else

--- a/app/controllers/lectures_controller.rb
+++ b/app/controllers/lectures_controller.rb
@@ -50,7 +50,7 @@ class LecturesController < ApplicationController
 
   # PATCH/PUT courses/:course_id/lectures/1
   def update
-    if !@lecture.enrollment_key && lecture_params[:enrollment_key]
+    if !@lecture.enrollment_key_present? && lecture_params[:enrollment_key]
       @lecture.participating_students.each do | student |
         @lecture.leave_lecture(student)
       end

--- a/spec/controllers/lectures_controller_spec.rb
+++ b/spec/controllers/lectures_controller_spec.rb
@@ -183,12 +183,11 @@ RSpec.describe LecturesController, type: :controller do
       end
 
       it "removes all joined students when adding key to keyless lecture", :logged_lecturer do
-        lecture = FactoryBot.create(:lecture, :keyless)
-        student = FactoryBot.create(:user, :student)
-        lecture.join_lecture(student)
-        put :update, params: { course_id: lecture.course.id, id: lecture.to_param, lecture: { enrollment_key: "firstKey" } }, session: valid_session
-        lecture.reload
-        expect(lecture.participating_students).to eq([])
+        @lecture.update(enrollment_key: nil)
+        @lecture.join_lecture(FactoryBot.create(:user, :student))
+        put :update, params: { course_id: @lecture.course.id, id: @lecture.to_param, lecture: new_attributes }, session: valid_session
+        @lecture.reload
+        expect(@lecture.participating_students.length).to eq(0)
       end
 
     end

--- a/spec/controllers/lectures_controller_spec.rb
+++ b/spec/controllers/lectures_controller_spec.rb
@@ -189,7 +189,6 @@ RSpec.describe LecturesController, type: :controller do
         @lecture.reload
         expect(@lecture.participating_students.length).to eq(0)
       end
-
     end
 
     context "with invalid params" do

--- a/spec/controllers/lectures_controller_spec.rb
+++ b/spec/controllers/lectures_controller_spec.rb
@@ -181,6 +181,16 @@ RSpec.describe LecturesController, type: :controller do
         put :update, params: { course_id: @lecture.course.id, id: @lecture.to_param, lecture: valid_attributes }, session: valid_session
         expect(response).to redirect_to(course_lecture_path(@lecture.course.id, @lecture))
       end
+
+      it "removes all joined students when adding key to keyless lecture", :logged_lecturer do
+        lecture = FactoryBot.create(:lecture, :keyless)
+        student = FactoryBot.create(:user, :student)
+        lecture.join_lecture(student)
+        put :update, params: { course_id: lecture.course.id, id: lecture.to_param, lecture: { enrollment_key: "firstKey" } }, session: valid_session
+        lecture.reload
+        expect(lecture.participating_students).to eq([])
+      end
+
     end
 
     context "with invalid params" do

--- a/spec/factories/lectures.rb
+++ b/spec/factories/lectures.rb
@@ -9,4 +9,8 @@ FactoryBot.define do
     start_time { "2020-01-01 10:10:00" }
     end_time { "2020-01-01 10:20:00" }
   end
+
+  trait :keyless do
+    enrollment_key { }
+  end
 end


### PR DESCRIPTION
# Resolves #number

This PR changes the update behavior of lectures so they remove all participating students when changing the enrollment_key from nonexistent to existent.

Acceptance Criteria:

- [ ]  If I entered a lecture before I don't need to input the key again
- [ ]  If the key changes inbetween logins I can still join the lecture without knowing the new key
- [ ]  If a lecture has no key, I join, and then a key is added, I need to enter the key
- [ ]  If I join a lecture, the lecturer removes the key, then later adds another key, and I join again, behaviour is undefined. That's the lecturers fault, just do whatever, we are running out of time and I don't care.

But only the third point is addressed in this PR because the others are already covered by dev ^.^
