### PR TITLE
add notice pages when polls or questions are disabled

### DIFF
--- a/app/views/lectures/show.html.erb
+++ b/app/views/lectures/show.html.erb
@@ -14,12 +14,21 @@
       <%= react_component("UpdatesApp",  {user_id: @current_user.id, is_student: @current_user.is_student, lecture_id: @lecture.id, course_id: @lecture.course.id} ) %>
     </div>
   </div>
+
   <div class="tab-pane fade" id="questions" role="tabpanel" aria-labelledby="questions-tab">
-    <%= react_component("QuestionsApp",  {user_id: @current_user.id, is_student: @current_user.is_student, lecture_id: @lecture.id, course_id: @lecture.course.id} ) %>
+    <% if @lecture.questions_enabled %>
+      <%= react_component("QuestionsApp",  {user_id: @current_user.id, is_student: @current_user.is_student, lecture_id: @lecture.id, course_id: @lecture.course.id} ) %>
+    <% else %>
+      <h1> Questions are not enabled. :(</h1>
+    <% end %>
   </div>
 
   <div class="tab-pane fade poll-tab-container" id="polls" role="tabpanel" aria-labelledby="polls-tab" >
-    <iframe class="polls-iframe" src="<%= course_lecture_polls_path(@course, @lecture) %>"></iframe>
+    <% if @lecture.polls_enabled%>
+      <iframe class="polls-iframe" src="<%= course_lecture_polls_path(@course, @lecture) %>"></iframe>
+    <% else %>
+      <h1> Polls are not enabled. :( </h1>
+    <% end %>
   </div>
 
   <div class="tab-pane fade" id="feedback" role="tabpanel" aria-labelledby="feedback-tab">

--- a/spec/views/lectures/show.html.erb_spec.rb
+++ b/spec/views/lectures/show.html.erb_spec.rb
@@ -64,8 +64,6 @@ RSpec.describe "lectures/show", type: :view do
     it "shows notice page on polls tab when polls are disabled" do
       @lecture.update(polls_enabled: false)
       render
-      # it displays one, but not in the polls section
-      expect(rendered).to have_css("iframe", count: 1)
       expect(rendered).to have_text("Polls are not enabled.")
     end
     it "shows notice page on questions tab when questions are disabled" do

--- a/spec/views/lectures/show.html.erb_spec.rb
+++ b/spec/views/lectures/show.html.erb_spec.rb
@@ -47,6 +47,25 @@ RSpec.describe "lectures/show", type: :view do
     it "renders a leave lecture button" do
       expect(rendered).not_to have_css("[value='Leave Lecture']")
     end
+    it "shows notice page on polls tab when polls are disabled" do
+      @lecture.update(polls_enabled: false)
+      render
+      # it displays one, but not in the polls section
+      expect(rendered).to have_css("iframe", count: 1)
+      expect(rendered).to have_text("Polls are not enabled.")
+    end
+    it "shows notice page on questions tab when questions are disabled" do
+      @lecture.update(questions_enabled: false)
+      render
+      assert_select "a", "Questions"
+      expect(rendered).to have_text("Questions are not enabled.")
+    end
+    it "does not show notice pages on disabled questions/polls when questions are enabled" do
+      render
+      assert_select "a", "Questions"
+      expect(rendered).to_not have_text("Questions are not enabled.")
+      expect(rendered).to_not have_text("Polls are not enabled.")
+    end
   end
 
   describe "as a student" do


### PR DESCRIPTION
# Resolves #203 

This PR changes the 

Acceptance Criteria:
QUESTIONS:
- [x] when the checkbox is checked (during creatioin or when changing settings) the feature works as implemented
- [x] if the checkbox is unchecked the text "Questions are disabled for this lecture" (or comparable) is displayed when opening the questions tab for both me and my students
- [x] if the checkbox is unchecked students can not ask questions

POLLS:
- [x] when the checkbox is checked (during creation or when changing settings) the feature works as intended
- [x]  if the checkbox is unchecked the text "Polls are disabled for this lecture" (or comparable) is displayed for both me and my students
- [x] If the checkbox is unchecked I can not start polls
