### PR TITLE
Disable upvoting and resolving for resolved questions

### DIFF
--- a/app/assets/stylesheets/questions.scss
+++ b/app/assets/stylesheets/questions.scss
@@ -91,6 +91,10 @@ div.questionsList {
       word-break: break-all;
       &.resolved {
         opacity: .4;
+        .arrow {
+          border-bottom-color: #eee !important;
+          cursor: default !important;
+        }
       }
       > .questionUpvotes {
         padding: 10px;

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -3,6 +3,8 @@ class QuestionsController < ApplicationController
   before_action :get_lecture
   before_action :validate_joined_user_or_owner
   before_action :validate_lecture_running_or_ended, except: [:index]
+  before_action :get_question, only: [:upvote, :resolve]
+  before_action :validate_question_unresolved, only: [:upvote, :resolve]
 
   # GET /questions
   def index
@@ -38,14 +40,12 @@ class QuestionsController < ApplicationController
 
   # POST /questions/:id/upvote
   def upvote
-    question = Question.find(params[:id])
-    if question && current_user.is_student && question.author != current_user && !question.upvoters.include?(current_user) && question.lecture == @lecture
-
-      question.upvoters << current_user
-      if question.save
+    if @question && current_user.is_student && @question.author != current_user && !@question.upvoters.include?(current_user) && @question.lecture == @lecture
+      @question.upvoters << current_user
+      if @question.save
         # broadcast upvote via ActionCable
         QuestionUpvotingChannel.broadcast_to(@lecture, {
-            question_id: question.id,
+            question_id: @question.id,
             upvoter_id: current_user.id
         })
         head :ok
@@ -57,13 +57,12 @@ class QuestionsController < ApplicationController
 
   # POST /questions/:id/resolve
   def resolve
-    question = Question.find(params[:id])
     # only allow author or lecturer to resolve the question
-    if question && (!current_user.is_student || question.author == current_user) && question.lecture == @lecture
-      question.resolved = true
-      if question.save
+    if @question && (!current_user.is_student || @question.author == current_user) && @question.lecture == @lecture
+      @question.resolved = true
+      if @question.save
         # broadcast resolving via ActionCable
-        QuestionResolvingChannel.broadcast_to(@lecture, question.id)
+        QuestionResolvingChannel.broadcast_to(@lecture, @question.id)
         head :ok
       end
     else
@@ -84,6 +83,14 @@ class QuestionsController < ApplicationController
     end
 
     def validate_lecture_running_or_ended
-      return head :forbidden if @lecture.readonly?
+      head :forbidden if @lecture.readonly?
+    end
+
+    def get_question
+      @question = Question.find(params[:id])
+    end
+
+    def validate_question_unresolved
+      head :forbidden if @question.resolved
     end
 end


### PR DESCRIPTION
# Relates to #73 

This PR changes the feature of upvoting/resolving questions so that resolved questions can not be upvoted/resolved.

Acceptance Criteria:
- [x] it is not possible to upvote/resolve a resolved question


Testing steps:
- create a question as student and resolve it
- try to upvote the question as another student

Steps needed for migration:
- none

---

Definition Of Done:
- [x] [Class-Diagram](https://www.lucidchart.com/invitations/accept/705a122b-58a9-4dfa-8b16-c936bc0a46bc) updated

