### PR TITLE
Feature/#220 filter ui

### DIFF
--- a/app/javascript/components/QuestionsList.tsx
+++ b/app/javascript/components/QuestionsList.tsx
@@ -26,6 +26,9 @@ const QuestionsList: React.FunctionComponent<{}> = observer(() => {
   };
 
   const checkQuestionFiltered = (question: QuestionModel): boolean => {
+    if (!(questionsList.filter_resolved || questionsList.filter_unresolved))
+      // if both filters are inactive, show all questions
+      return true;
     return (question.resolved && questionsList.filter_resolved) ||
       (!question.resolved && questionsList.filter_unresolved);
   };

--- a/app/javascript/components/QuestionsList.tsx
+++ b/app/javascript/components/QuestionsList.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { observer } from "mobx-react";
 import Question from "./Question";
 import { QuestionsRootStoreModel } from "../stores/QuestionsRootStore";
-import {useInjectQuestions} from "../hooks/useInject";
-import {QuestionModel} from "../stores/Question";
+import { useInjectQuestions } from "../hooks/useInject";
+import { QuestionModel } from "../stores/Question";
 
 const mapStore = ({ is_student, questionsList, interactions_enabled }: QuestionsRootStoreModel) => ({
   is_student,
@@ -19,26 +19,26 @@ const QuestionsList: React.FunctionComponent<{}> = observer(() => {
   };
 
   const onFilterResolvedClick = () => {
-      questionsList.toggleFilterResolved();
+    questionsList.toggleFilterResolved();
   };
   const onFilterUnresolvedClick = () => {
-      questionsList.toggleFilterUnresolved();
+    questionsList.toggleFilterUnresolved();
   };
 
-  const checkQuestionFiltered = (question: QuestionModel) : boolean => {
-      return (question.resolved && questionsList.filter_resolved) ||
-        (!question.resolved && questionsList.filter_unresolved);
+  const checkQuestionFiltered = (question: QuestionModel): boolean => {
+    return (question.resolved && questionsList.filter_resolved) ||
+      (!question.resolved && questionsList.filter_unresolved);
   };
 
   return (
-    <div className={"questionsList" + (interactions_enabled && is_student ? " interactions_enabled" : "" )}>
+    <div className={"questionsList" + (interactions_enabled && is_student ? " interactions_enabled" : "")}>
       <div className="questionsFilter">
         <div className="filtering">
-            <button className={"btn btn-secondary " + (is_student ? "btn-sm" : "btn-lg") + (questionsList.filter_resolved ? " active" : "")} onClick={onFilterResolvedClick}>
-                resolved
+          <button className={"btn btn-secondary " + (is_student ? "btn-sm" : "btn-lg") + (questionsList.filter_unresolved ? " active" : "")} onClick={onFilterUnresolvedClick}>
+            unresolved
             </button>
-            <button className={"btn btn-secondary " + (is_student ? "btn-sm" : "btn-lg") + (questionsList.filter_unresolved ? " active" : "")} onClick={onFilterUnresolvedClick}>
-                unresolved
+          <button className={"btn btn-secondary " + (is_student ? "btn-sm" : "btn-lg") + (questionsList.filter_resolved ? " active" : "")} onClick={onFilterResolvedClick}>
+            resolved
             </button>
         </div>
         <div className="sorting" onClick={onSortingClick}>

--- a/app/javascript/stores/QuestionsList.ts
+++ b/app/javascript/stores/QuestionsList.ts
@@ -75,12 +75,20 @@ const QuestionsList = types
             self.list = sortQuestionsList(self.list, self.is_sorted_by_time)
         },
         toggleFilterResolved() {
-            // only turn off resolved filter if unresolved filter is on
-            self.filter_resolved = !self.filter_resolved || !self.filter_unresolved;
+            if (self.filter_resolved)
+                self.filter_resolved = false;
+            else {
+                self.filter_resolved = true;
+                self.filter_unresolved = false;
+            }
         },
         toggleFilterUnresolved() {
-            // only turn off unresolved filter if resolved filter is on
-            self.filter_unresolved = !self.filter_unresolved || !self.filter_resolved;
+            if (self.filter_unresolved)
+                self.filter_unresolved = false;
+            else {
+                self.filter_unresolved = true;
+                self.filter_resolved = false;
+            }
         }
     }));
 


### PR DESCRIPTION
# Resolves #220

This PR changes the behavior of question filtering buttons.

Acceptance Criteria:
- [x] Unresolved button is placed on the left
- [x] Clicking on an inactive filter button switches to that filter
- [x] Clicking on an active filter button disables (grey) all filters

Testing steps:
- toggle question filter buttons

Steps needed for migration: None

---

Definition Of Done:
- [x] [Class-Diagram](https://www.lucidchart.com/invitations/accept/705a122b-58a9-4dfa-8b16-c936bc0a46bc) updated

