### PR TITLE
implement full width dashboard properly

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -43,3 +43,9 @@ $success: #00911f;
 @import "lectures";
 @import "polls";
 @import "courses";
+
+img,
+video,
+canvas {
+  max-width: 100%;
+}

--- a/app/controllers/lectures_controller.rb
+++ b/app/controllers/lectures_controller.rb
@@ -22,6 +22,7 @@ class LecturesController < ApplicationController
   def show
     @current_user = current_user
     @uploaded_files = @lecture.uploaded_files
+    render layout: "application-full"
   end
 
   # GET courses/:course_id/lectures/new

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -51,8 +51,10 @@
   <% if @current_user.is_student %>
     <%= link_to "Leave", leave_course_path(id: @course.id), method: :post, class:"btn btn-primary" %> |
   <% end %>
+
   <% if !@current_user.is_student %>
     <%= link_to 'Edit', edit_course_path(@course) %> |
   <% end %>
-  <%= link_to 'Back', root_path %>
+
+  <%= link_to (fa_icon 'arrow-left', text: 'Back'), root_path %>
 </div>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -47,10 +47,12 @@
 <% end %>
 
 
-<% if @current_user.is_student %>
-  <%= link_to "Leave", leave_course_path(id: @course.id), method: :post, class:"btn btn-primary" %> |
-<% end %>
-<% if !@current_user.is_student %>
-  <%= link_to 'Edit', edit_course_path(@course) %> |
-<% end %>
-<%= link_to 'Back', root_path %>
+<div class="d-flex justify-content-center">
+  <% if @current_user.is_student %>
+    <%= link_to "Leave", leave_course_path(id: @course.id), method: :post, class:"btn btn-primary" %> |
+  <% end %>
+  <% if !@current_user.is_student %>
+    <%= link_to 'Edit', edit_course_path(@course) %> |
+  <% end %>
+  <%= link_to 'Back', root_path %>
+</div>

--- a/app/views/layouts/_application-head.html.erb
+++ b/app/views/layouts/_application-head.html.erb
@@ -1,0 +1,10 @@
+<title>LecturePortal</title>
+<%= csrf_meta_tags %>
+<%= csp_meta_tag %>
+<!-- Bootstrap meta tags -->
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+<%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+<%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+<%= javascript_pack_tag    'application' %>

--- a/app/views/layouts/application-full.html.erb
+++ b/app/views/layouts/application-full.html.erb
@@ -1,16 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>LecturePortal</title>
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
-    <!-- Bootstrap meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_pack_tag    'application' %>
+    <%= render "application-head" %>
   </head>
 
   <body>

--- a/app/views/layouts/application-full.html.erb
+++ b/app/views/layouts/application-full.html.erb
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>LecturePortal</title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <!-- Bootstrap meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_pack_tag    'application' %>
+  </head>
+
+  <body>
+    <% if !@hide_navbar %>
+      <%= render "layouts/navbar" %>
+    <% end %>
+    <%# Bootstrap container, https://getbootstrap.com/docs/4.0/layout/overview/ %>
+    <main role="main" class="container-fluid mt-4 px-4">
+      <div class="container">
+        <% if notice %><div class="alert alert-success notice" role="alert"><%= notice %></div><% end %>
+        <% if alert %><div class="alert alert-danger" role="alert"><%= alert %></div><% end %>
+      </div>
+      <%= yield %>
+    </main>
+  </body>
+</html>

--- a/app/views/layouts/application-full.html.erb
+++ b/app/views/layouts/application-full.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <%= render "application-head" %>
+    <%= render "layouts/application-head" %>
   </head>
 
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,16 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>LecturePortal</title>
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
-    <!-- Bootstrap meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_pack_tag    'application' %>
+    <%= render "application-head" %>
   </head>
 
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <%= render "application-head" %>
+    <%= render "layouts/application-head" %>
   </head>
 
   <body>

--- a/app/views/lectures/show.html.erb
+++ b/app/views/lectures/show.html.erb
@@ -11,6 +11,8 @@
   <% if @lecture.start_time && @lecture.end_time && @lecture.date%>
     <p><%= @lecture.date.strftime("%d.%m.%Y") %> <%= @lecture.start_time.strftime("%H:%M -") %> <%= @lecture.end_time.strftime("%H:%M") %></p>
   <% end %>
+
+  <%= render 'tabbar', current_user: @current_user %>
 </div>
 
 <div class="tab-content" id="lectureTabsContent">

--- a/app/views/lectures/show.html.erb
+++ b/app/views/lectures/show.html.erb
@@ -10,7 +10,7 @@
 <div class="tab-content" id="lectureTabsContent">
   <div class="tab-pane fade show active mx-auto" id="dashboard" role="tabpanel" aria-labelledby="dashboard-tab" style="max-width: 2000px;">
     <div class="row">
-      <div id="updates" class="col col-md-6 col-xl-4">
+      <div id="updates" class="col-12 col-sm-6 col-xl-4">
           <% if @current_user.is_student %>
             <h2 class="h5">Updates</h2>
           <% else %>
@@ -18,14 +18,14 @@
           <% end %>
           <%= react_component("UpdatesApp", {user_id: @current_user.id, is_student: @current_user.is_student, lecture_id: @lecture.id, course_id: @lecture.course.id, interactions_enabled: !@lecture.readonly?}) %>
       </div>
-      <div id="materials" class="col col-md-6 col-xl-4 ">
+      <div id="materials" class="col-12 col-sm-6 col-xl-4 ">
         <h2 class="h5">Materials</h2>
         <%= render 'components/show_uploaded_files_or_links', uploaded_files: @uploaded_files %>
         <% unless current_user.is_student %>
           <%= link_to "Add lecture material", new_course_lecture_uploaded_file_path(@lecture.course, @lecture), class:"btn btn-link"%>
         <% end %>
       </div>
-      <div id="comprehension" class="col col-md-6 col-xl-4">
+      <div id="comprehension" class="col-12 col-sm-6 col-xl-4">
         <h2 class="h5">Comprehension Level</h2>
         <%= react_component("ComprehensionApp",  {user_id: @current_user.id, is_student: @current_user.is_student, lecture_id: @lecture.id, course_id: @lecture.course.id, interactions_enabled: !@lecture.readonly?} ) %>
       </div>

--- a/app/views/lectures/show.html.erb
+++ b/app/views/lectures/show.html.erb
@@ -6,14 +6,12 @@
     }
 </script>
 
-<div class="container">
-  <h1 class="h5"><%= @lecture.name %></h1>
-  <% if @lecture.start_time && @lecture.end_time && @lecture.date%>
-    <p><%= @lecture.date.strftime("%d.%m.%Y") %> <%= @lecture.start_time.strftime("%H:%M -") %> <%= @lecture.end_time.strftime("%H:%M") %></p>
-  <% end %>
+<h1 class="h5"><%= @lecture.name %></h1>
+<% if @lecture.start_time && @lecture.end_time && @lecture.date%>
+  <p><%= @lecture.date.strftime("%d.%m.%Y") %> <%= @lecture.start_time.strftime("%H:%M -") %> <%= @lecture.end_time.strftime("%H:%M") %></p>
+<% end %>
 
-  <%= render 'tabbar', current_user: @current_user %>
-</div>
+<%= render 'tabbar', current_user: @current_user %>
 
 <div class="tab-content" id="lectureTabsContent">
   <div class="tab-pane fade show active mx-auto" id="dashboard" role="tabpanel" aria-labelledby="dashboard-tab" style="max-width: 2000px;">

--- a/app/views/lectures/show.html.erb
+++ b/app/views/lectures/show.html.erb
@@ -1,11 +1,14 @@
-<h5><%= @lecture.name %></h5>
-<% if @lecture.start_time &&  @lecture.end_time && @lecture.date%>
-  <p><%= @lecture.date.strftime("%d.%m.%Y") %> <%= @lecture.start_time.strftime("%H:%M -") %> <%= @lecture.end_time.strftime("%H:%M") %></p>
-<% end %>
+<div class="container">
+  <h1 class="h5"><%= @lecture.name %></h1>
+  <% if @lecture.start_time &&  @lecture.end_time && @lecture.date%>
+    <p><%= @lecture.date.strftime("%d.%m.%Y") %> <%= @lecture.start_time.strftime("%H:%M -") %> <%= @lecture.end_time.strftime("%H:%M") %></p>
+  <% end %>
 
-<%= render 'tabbar', current_user: @current_user %>
+  <%= render 'tabbar', current_user: @current_user %>
+</div>
+
 <div class="tab-content" id="lectureTabsContent">
-  <div class="tab-pane fade show active" id="dashboard" role="tabpanel" aria-labelledby="dashboard-tab">
+  <div class="tab-pane fade show active mx-auto" id="dashboard" role="tabpanel" aria-labelledby="dashboard-tab" style="max-width: 2000px;">
     <div class="row">
       <div id="updates" class="col col-md-6 col-xl-4">
           <% if @current_user.is_student %>
@@ -29,7 +32,7 @@
     </div>
   </div>
 
-  <div class="tab-pane fade" id="questions" role="tabpanel" aria-labelledby="questions-tab">
+  <div class="container tab-pane fade" id="questions" role="tabpanel" aria-labelledby="questions-tab">
     <% if @lecture.questions_enabled %>
       <%= react_component("QuestionsApp",  {user_id: @current_user.id, is_student: @current_user.is_student, lecture_id: @lecture.id, course_id: @lecture.course.id, interactions_enabled: !@lecture.readonly?} ) %>
     <% else %>
@@ -37,7 +40,7 @@
     <% end %>
   </div>
 
-  <div class="tab-pane fade poll-tab-container" id="polls" role="tabpanel" aria-labelledby="polls-tab" >
+  <div class="container tab-pane fade poll-tab-container" id="polls" role="tabpanel" aria-labelledby="polls-tab" >
     <% if @lecture.polls_enabled%>
       <iframe class="polls-iframe" src="<%= course_lecture_polls_path(@course, @lecture) %>"></iframe>
     <% else %>
@@ -45,7 +48,7 @@
     <% end %>
   </div>
 
-  <div class="tab-pane fade" id="feedback" role="tabpanel" aria-labelledby="feedback-tab">
+  <div class="container tab-pane fade" id="feedback" role="tabpanel" aria-labelledby="feedback-tab">
     <% if @current_user.is_student %>
       <%= form_with(model: [ @course, @lecture, @lecture.feedbacks.build ]) do |form| %>
         <p>
@@ -65,9 +68,10 @@
       <% end %>
     <% end %>
   </div>
+
   <% if !@current_user.is_student %>
     <% if @lecture.enrollment_key_present? %>
-      <div class="tab-pane fade" id="enrollmentKey" role="tabpanel" aria-labelledby="enrollmentKey-tab-tab">
+      <div class="container tab-pane fade" id="enrollmentKey" role="tabpanel" aria-labelledby="enrollmentKey-tab-tab">
         <h1 class="padded-text">Enrollment Key: <%= @lecture.enrollment_key %></h1>
         <h3 class="padded-text"> Students </h3>
           <ol>
@@ -77,22 +81,12 @@
           </ol>
       </div>
     <% end %>
-    <div class="tab-pane fade" id="settings" role="tabpanel" aria-labelledby="settings-tab">
+    <div class="container tab-pane fade" id="settings" role="tabpanel" aria-labelledby="settings-tab">
       <%= render 'form', lecture: @lecture %>
     </div>
   <% end %>
 </div>
 
-<table>
-  <tr>
-    <td colspan="2"><%= link_to 'Back', course_path(@course), class:"btn btn-link" %> </td>
-    <% if !@current_user.is_student %>
-      <% if @lecture.created? %>
-          <td colspan="2"> | <%= link_to "Edit", edit_course_lecture_path(course_id: @lecture.course.id, id: @lecture.id), class:"btn btn-link" %></td>
-        <td colspan="2"> | <%= link_to "Start", start_lecture_path(course_id: @lecture.course.id, id: @lecture.id), method: :post, class:"btn btn-link" %></td>
-      <% elsif @lecture.running? %>
-        <td colspan="2"> | <%= link_to 'New Poll', new_course_lecture_poll_path(@course, @lecture), {class:"btn btn-link"} %> </td>
-      <%end %>
-  <%end %>
-  </tr>
-</table>
+<div class="d-flex justify-content-center">
+  <%= link_to (fa_icon 'arrow-left', text: 'Back'), course_path(@course), class:"btn btn-link" %>
+</div>


### PR DESCRIPTION
Reimplements the full widht layout of the dashboard properly

- adds a new full-width layout
- adjust the lecture view to use new layout and wrap most elements into a container to center it again like it was before ([https://getbootstrap.com/docs/4.4/layout/overview/#containers](https://getbootstrap.com/docs/4.4/layout/overview/#containers))

![image](https://user-images.githubusercontent.com/22987140/72986149-d5af5a00-3de7-11ea-8682-8383ba638507.png)
