### PR TITLE
Fix comprehension disabled after lecture ended

### DIFF
--- a/app/views/lectures/show.html.erb
+++ b/app/views/lectures/show.html.erb
@@ -40,7 +40,7 @@
         <% end %>
         <div id="comprehension">
           <h2 class="h5">Comprehension Level</h2>
-          <%= react_component("ComprehensionApp",  {user_id: @current_user.id, is_student: @current_user.is_student, lecture_id: @lecture.id, course_id: @lecture.course.id, comprehension_state: @lecture.comprehension_state(current_user)} ) %>
+          <%= react_component("ComprehensionApp",  {user_id: @current_user.id, is_student: @current_user.is_student, lecture_id: @lecture.id, course_id: @lecture.course.id, interactions_enabled: !@lecture.readonly?, comprehension_state: @lecture.comprehension_state(current_user)}) %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Resolves Issues

This PR fixes that comprehension buttons are disabled after lecture ended

Testing steps:
- end lecture as lecturer
- no comprehension votes are possible as student

---

Definition Of Done:
- [x] [Class-Diagram](https://www.lucidchart.com/invitations/accept/705a122b-58a9-4dfa-8b16-c936bc0a46bc) updated

