### PR TITLE
Feature/#230 student dashboard upvote update feed

### DIFF
--- a/app/assets/stylesheets/lecture_updates.scss
+++ b/app/assets/stylesheets/lecture_updates.scss
@@ -12,18 +12,25 @@
       text-align: center;
       margin-bottom: 0;
       padding: 0 10px;
-      
-      &.is_lecturer {
-        > li.interactable {
+
+      > li {
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+
+        &.interactable {
           cursor: pointer;
           &:hover {
-            background-color: #d4fcd2;
+            background-color: #ddd !important;
           }
         }
-      }
-
-      > li:last-child {
-        margin-bottom: 0;
+        &.marked {
+          border: 1px solid #f2994a;
+        }
+        &:last-child {
+          margin-bottom: 0;
+        }
       }
     }
   }

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,6 +1,5 @@
 class QuestionsController < ApplicationController
   before_action :authenticate_user!
-  skip_before_action :verify_authenticity_token
   before_action :get_course
   before_action :get_lecture
   before_action :validate_joined_user_or_owner

--- a/app/javascript/components/Question.tsx
+++ b/app/javascript/components/Question.tsx
@@ -2,53 +2,57 @@ import React from "react";
 import { observer } from "mobx-react";
 import { QuestionModel } from "../stores/Question";
 import { QuestionsRootStoreModel } from "../stores/QuestionsRootStore";
-import {useInjectQuestions} from "../hooks/useInject";
+import { useInjectQuestions } from "../hooks/useInject";
 
 const mapStore = ({ is_student }: QuestionsRootStoreModel) => ({
-    is_student
+  is_student
 });
 
 type Props = {
-    question: QuestionModel
-}
-
-const QuestionView: React.FunctionComponent<Props> = ({ question }) => {
-    const { is_student } = useInjectQuestions(mapStore);
-
-    const canQuestionBeUpvoted: boolean =
-        question.canBeUpvoted();
-    const isQuestionAlreadyUpvoted: boolean =
-        question.isAlreadyUpvoted();
-    const canQuestionBeResolved: boolean =
-        question.canBeResolved();
-
-    const onResolveClick = _ => {
-        canQuestionBeResolved && question.resolveClick()
-    };
-
-    const onUpvoteClick = _ => {
-        canQuestionBeUpvoted && question.upvoteClick()
-    };
-    return (
-        <li key={question.id} className={question.resolved ? "resolved" : ""}>
-            <div className={"questionUpvotes " + (!canQuestionBeUpvoted ? "disabled" : "") + (isQuestionAlreadyUpvoted ? " upvoted" : "")}>
-                <div className="arrow" onClick={onUpvoteClick} />
-                <p className="count">{question.upvotes}</p>
-            </div>
-            <div className="questionContent">
-                {question.content}
-            </div>
-
-            {!question.resolved && canQuestionBeResolved &&
-                <button className={"btn btn-secondary " + (is_student ? "btn-sm" : "btn-lg")} onClick={onResolveClick}>
-                    mark as solved
-                </button>}
-            {question.resolved &&
-                <span className={is_student ? "btn-sm" : "btn-lg"}>
-                    resolved
-                </span>}
-        </li>
-    );
+  question: QuestionModel;
 };
 
-export default observer(QuestionView)
+const QuestionView: React.FunctionComponent<Props> = ({ question }) => {
+  const { is_student } = useInjectQuestions(mapStore);
+
+  const canQuestionBeUpvoted: boolean = question.canBeUpvoted();
+  const isQuestionAlreadyUpvoted: boolean = question.isAlreadyUpvoted();
+  const canQuestionBeResolved: boolean = question.canBeResolved();
+
+  const onResolveClick = _ => {
+    canQuestionBeResolved && question.resolveClick();
+  };
+
+  const onUpvoteClick = _ => {
+    canQuestionBeUpvoted && !isQuestionAlreadyUpvoted && question.upvoteClick();
+  };
+  return (
+    <li key={question.id} className={question.resolved ? "resolved" : ""}>
+      <div
+        className={
+          "questionUpvotes " +
+          (!canQuestionBeUpvoted ? "disabled" : "") +
+          (isQuestionAlreadyUpvoted ? " upvoted" : "")
+        }
+      >
+        <div className="arrow" onClick={onUpvoteClick} />
+        <p className="count">{question.upvotes}</p>
+      </div>
+      <div className="questionContent">{question.content}</div>
+
+      {!question.resolved && canQuestionBeResolved && (
+        <button
+          className={"btn btn-secondary " + (is_student ? "btn-sm" : "btn-lg")}
+          onClick={onResolveClick}
+        >
+          mark as solved
+        </button>
+      )}
+      {question.resolved && (
+        <span className={is_student ? "btn-sm" : "btn-lg"}>resolved</span>
+      )}
+    </li>
+  );
+};
+
+export default observer(QuestionView);

--- a/app/javascript/components/Update.tsx
+++ b/app/javascript/components/Update.tsx
@@ -4,8 +4,9 @@ import { useInjectUpdates } from "../hooks/useInject";
 import { UpdatesRootStoreModel } from "../stores/UpdatesRootStore";
 import { UpdateItem } from "../stores/UpdateItem";
 
-const mapStore = ({ is_student, interactions_enabled }: UpdatesRootStoreModel) => ({
+const mapStore = ({ is_student, user_id, interactions_enabled }: UpdatesRootStoreModel) => ({
     is_student,
+    user_id,
     interactions_enabled
 });
 
@@ -14,7 +15,12 @@ type Props = {
 }
 
 const UpdateView: React.FunctionComponent<Props> = ({ item }) => {
-    const { is_student, interactions_enabled } = useInjectUpdates(mapStore);
+    const { is_student, user_id, interactions_enabled } = useInjectUpdates(mapStore);
+
+    const isInteractable = (): boolean => {
+        if(!interactions_enabled) return false;
+        return item.isInteractable(is_student, user_id)
+    };
 
     const onClick = _ => {
         if(interactions_enabled) {
@@ -25,7 +31,7 @@ const UpdateView: React.FunctionComponent<Props> = ({ item }) => {
 
     return (
         <li key={item.id} onClick={onClick} className={
-            (interactions_enabled ? "interactable" : "") +
+            (isInteractable() ? "interactable" : "") +
             (is_student && item.isMarked() ? " marked" : "")
         }>
             <div className="questionContent p-4">

--- a/app/javascript/components/Update.tsx
+++ b/app/javascript/components/Update.tsx
@@ -4,42 +4,57 @@ import { useInjectUpdates } from "../hooks/useInject";
 import { UpdatesRootStoreModel } from "../stores/UpdatesRootStore";
 import { UpdateItem } from "../stores/UpdateItem";
 
-const mapStore = ({ is_student, user_id, interactions_enabled }: UpdatesRootStoreModel) => ({
-    is_student,
-    user_id,
-    interactions_enabled
+const mapStore = ({
+  is_student,
+  user_id,
+  interactions_enabled
+}: UpdatesRootStoreModel) => ({
+  is_student,
+  user_id,
+  interactions_enabled
 });
 
 type Props = {
-    item: UpdateItem
-}
-
-const UpdateView: React.FunctionComponent<Props> = ({ item }) => {
-    const { is_student, user_id, interactions_enabled } = useInjectUpdates(mapStore);
-
-    const isInteractable = (): boolean => {
-        if(!interactions_enabled) return false;
-        return item.isInteractable(is_student, user_id)
-    };
-
-    const onClick = _ => {
-        if(interactions_enabled) {
-            is_student && item.onStudentClick();
-            !is_student && item.onLecturerClick();
-        }
-    };
-
-    return (
-        <li key={item.id} onClick={onClick} className={
-            (isInteractable() ? "interactable" : "") +
-            (is_student && item.isMarked() ? " marked" : "")
-        }>
-            <div className="questionContent p-4">
-                {is_student && <span><b>{item.getTitle()}</b><br /></span>}
-                {item.getContent()}
-            </div>
-        </li>
-    );
+  item: UpdateItem;
 };
 
-export default observer(UpdateView)
+const UpdateView: React.FunctionComponent<Props> = ({ item }) => {
+  const { is_student, user_id, interactions_enabled } = useInjectUpdates(
+    mapStore
+  );
+
+  const isInteractable = (): boolean => {
+    if (!interactions_enabled) return false;
+    return item.isInteractable(is_student, user_id);
+  };
+
+  const onClick = _ => {
+    if (isInteractable()) {
+      is_student && item.onStudentClick();
+      !is_student && item.onLecturerClick();
+    }
+  };
+
+  return (
+    <li
+      key={item.id}
+      onClick={onClick}
+      className={
+        (isInteractable() ? "interactable" : "") +
+        (is_student && item.isMarked() ? " marked" : "")
+      }
+    >
+      <div className="questionContent p-4">
+        {is_student && (
+          <span>
+            <b>{item.getTitle()}</b>
+            <br />
+          </span>
+        )}
+        {item.getContent()}
+      </div>
+    </li>
+  );
+};
+
+export default observer(UpdateView);

--- a/app/javascript/components/Update.tsx
+++ b/app/javascript/components/Update.tsx
@@ -17,11 +17,17 @@ const UpdateView: React.FunctionComponent<Props> = ({ item }) => {
     const { is_student, interactions_enabled } = useInjectUpdates(mapStore);
 
     const onClick = _ => {
-        interactions_enabled && item.onClick(is_student)
+        if(interactions_enabled) {
+            is_student && item.onStudentClick();
+            !is_student && item.onLecturerClick();
+        }
     };
 
     return (
-        <li key={item.id} onClick={onClick} className={interactions_enabled ? "interactable" : ""}>
+        <li key={item.id} onClick={onClick} className={
+            (interactions_enabled ? "interactable" : "") +
+            (is_student && item.isMarked() ? " marked" : "")
+        }>
             <div className="questionContent p-4">
                 {is_student && <span><b>{item.getTitle()}</b><br /></span>}
                 {item.getContent()}

--- a/app/javascript/components/Update.tsx
+++ b/app/javascript/components/Update.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { observer } from "mobx-react";
-import {useInjectUpdates} from "../hooks/useInject";
-import {UpdatesRootStoreModel} from "../stores/UpdatesRootStore";
-import {UpdateItem} from "../stores/UpdateItem";
+import { useInjectUpdates } from "../hooks/useInject";
+import { UpdatesRootStoreModel } from "../stores/UpdatesRootStore";
+import { UpdateItem } from "../stores/UpdateItem";
 
 const mapStore = ({ is_student, interactions_enabled }: UpdatesRootStoreModel) => ({
     is_student,
@@ -13,11 +13,11 @@ type Props = {
     item: UpdateItem
 }
 
-const UpdateView: React.FunctionComponent<Props> = ({item}) => {
+const UpdateView: React.FunctionComponent<Props> = ({ item }) => {
     const { is_student, interactions_enabled } = useInjectUpdates(mapStore);
 
     const onClick = _ => {
-        !is_student && interactions_enabled && item.onClick()
+        interactions_enabled && item.onClick(is_student)
     };
 
     return (

--- a/app/javascript/stores/Question.ts
+++ b/app/javascript/stores/Question.ts
@@ -1,6 +1,7 @@
 import { Instance, types } from "mobx-state-tree";
 import { resolveQuestionById, upvoteQuestionById } from "../utils/QuestionsUtils";
 import { getQuestionsRootStore } from "./QuestionsRootStore";
+import { getUpdatesRootStore } from "./UpdatesRootStore";
 
 export type QuestionModel = Instance<typeof Question>
 
@@ -35,8 +36,11 @@ const Question = types
     disallowUpvote() {
       self.already_upvoted = true;
     },
-    resolveClick() {
-      resolveQuestionById(self.id);
+    updateClick(is_student: boolean) {
+      if (is_student)
+        upvoteQuestionById(self.id);
+      else
+        resolveQuestionById(self.id);
     },
     upvoteClick() {
       upvoteQuestionById(self.id);

--- a/app/javascript/stores/Question.ts
+++ b/app/javascript/stores/Question.ts
@@ -36,11 +36,8 @@ const Question = types
     disallowUpvote() {
       self.already_upvoted = true;
     },
-    updateClick(is_student: boolean) {
-      if (is_student)
-        upvoteQuestionById(self.id);
-      else
-        resolveQuestionById(self.id);
+    resolveClick() {
+      resolveQuestionById(self.id);
     },
     upvoteClick() {
       upvoteQuestionById(self.id);

--- a/app/javascript/stores/UpdateItem.ts
+++ b/app/javascript/stores/UpdateItem.ts
@@ -31,12 +31,28 @@ export class UpdateItem {
             }
         }
     }
-    onClick(is_student: boolean) {
+    onStudentClick() {
         switch (this.type) {
             case (UpdateTypes.Question): {
-                (this.item.value as QuestionModel).updateClick(is_student);
+                (this.item.value as QuestionModel).upvoteClick();
                 break;
             }
+        }
+    }
+    onLecturerClick() {
+        switch (this.type) {
+            case (UpdateTypes.Question): {
+                (this.item.value as QuestionModel).resolveClick();
+                break;
+            }
+        }
+    }
+    isMarked(): boolean {
+        switch (this.type) {
+            case (UpdateTypes.Question): {
+                return (this.item.value as QuestionModel).already_upvoted;
+            }
+            default: return false;
         }
     }
 }

--- a/app/javascript/stores/UpdateItem.ts
+++ b/app/javascript/stores/UpdateItem.ts
@@ -1,4 +1,4 @@
-import {QuestionModel} from "./Question";
+import { QuestionModel } from "./Question";
 
 export enum UpdateTypes {
     Question, Poll
@@ -10,31 +10,31 @@ export class UpdateItem {
         this.id = type + "-" + item.value.id
     }
     isVisible(): boolean {
-        switch(this.type) {
-            case(UpdateTypes.Question): {
+        switch (this.type) {
+            case (UpdateTypes.Question): {
                 return !(this.item.value as QuestionModel).resolved
             }
         }
         return true;
     }
     getTitle(): string {
-        switch(this.type) {
-            case(UpdateTypes.Question): {
+        switch (this.type) {
+            case (UpdateTypes.Question): {
                 return "Question";
             }
         }
     }
     getContent(): string {
-        switch(this.type) {
-            case(UpdateTypes.Question): {
+        switch (this.type) {
+            case (UpdateTypes.Question): {
                 return (this.item.value as QuestionModel).content;
             }
         }
     }
-    onClick() {
-        switch(this.type) {
-            case(UpdateTypes.Question): {
-                (this.item.value as QuestionModel).resolveClick();
+    onClick(is_student: boolean) {
+        switch (this.type) {
+            case (UpdateTypes.Question): {
+                (this.item.value as QuestionModel).updateClick(is_student);
                 break;
             }
         }

--- a/app/javascript/stores/UpdateItem.ts
+++ b/app/javascript/stores/UpdateItem.ts
@@ -55,4 +55,16 @@ export class UpdateItem {
             default: return false;
         }
     }
+    isInteractable(isStudent: boolean, userId: number): boolean {
+        switch (this.type) {
+            case (UpdateTypes.Question): {
+                if(isStudent)
+                    return !(this.item.value as QuestionModel).already_upvoted
+                        && (this.item.value as QuestionModel).author_id != userId;
+                else
+                    return true;
+            }
+            default: return false;
+        }
+    }
 }

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -13,12 +13,20 @@ class Question < ApplicationRecord
 
   def Question.questions_for_lecture(lecture, current_user)
     if current_user.is_student
-      Question.where(lecture: lecture).order(created_at: :DESC)
+      ActiveModelSerializers::SerializableResource.new(
+          Question.where(lecture: lecture).order(created_at: :DESC),
+          each_serializer: QuestionSerializer,
+          current_user: current_user
+      )
     else
-      Question.where(lecture: lecture)
-        .left_joins(:upvoters)
-        .group(:id)
-        .order(Arel.sql("COUNT(users.id) DESC"), created_at: :DESC)
+      ActiveModelSerializers::SerializableResource.new(
+          Question.where(lecture: lecture)
+              .left_joins(:upvoters)
+              .group(:id)
+              .order(Arel.sql("COUNT(users.id) DESC"), created_at: :DESC),
+          each_serializer: QuestionSerializer,
+          current_user: current_user
+      )
     end
   end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -14,16 +14,16 @@ class Question < ApplicationRecord
   def Question.questions_for_lecture(lecture, current_user)
     if current_user.is_student
       ActiveModelSerializers::SerializableResource.new(
-          Question.where(lecture: lecture).order(created_at: :DESC),
+        Question.where(lecture: lecture).order(created_at: :DESC),
           each_serializer: QuestionSerializer,
           current_user: current_user
       )
     else
       ActiveModelSerializers::SerializableResource.new(
-          Question.where(lecture: lecture)
-              .left_joins(:upvoters)
-              .group(:id)
-              .order(Arel.sql("COUNT(users.id) DESC"), created_at: :DESC),
+        Question.where(lecture: lecture)
+            .left_joins(:upvoters)
+            .group(:id)
+            .order(Arel.sql("COUNT(users.id) DESC"), created_at: :DESC),
           each_serializer: QuestionSerializer,
           current_user: current_user
       )

--- a/app/serializers/question_serializer.rb
+++ b/app/serializers/question_serializer.rb
@@ -2,7 +2,7 @@ class QuestionSerializer < ActiveModel::Serializer
   attributes :id, :content, :author_id, :created_at, :upvotes, :already_upvoted, :resolved
 
   def already_upvoted
-    if defined?(current_user) and current_user != nil
+    if defined?(current_user) && (current_user != nil)
       (current_user.id != object.author_id) && (object.upvoter_ids.include?(current_user.id))
     end
   end

--- a/app/serializers/question_serializer.rb
+++ b/app/serializers/question_serializer.rb
@@ -2,8 +2,12 @@ class QuestionSerializer < ActiveModel::Serializer
   attributes :id, :content, :author_id, :created_at, :upvotes, :already_upvoted, :resolved
 
   def already_upvoted
-    if defined?(current_user)
+    if defined?(current_user) and current_user != nil
       (current_user.id != object.author_id) && (object.upvoter_ids.include?(current_user.id))
     end
+  end
+
+  def current_user
+    @instance_options[:current_user]
   end
 end

--- a/spec/controllers/questions_controller_spec.rb
+++ b/spec/controllers/questions_controller_spec.rb
@@ -136,7 +136,10 @@ RSpec.describe QuestionsController, type: :controller do
         not_upvoted_question = FactoryBot.create(:question, author: another_student, lecture: @lecture)
         sign_in(another_student, scope: :user)
         post :upvote, params: { course_id: @lecture.course.id, lecture_id: @lecture.id, id: @question.id }, session: valid_session
-        expected = [ @question, not_upvoted_question ]
+        expected = ActiveModelSerializers::SerializableResource.new(
+            [@question, not_upvoted_question],
+            each_serializer: QuestionSerializer,
+            current_user: @lecturer)
         expect(Question.questions_for_lecture(@lecture, @lecturer).to_json).to eq(expected.to_json)
       end
     end

--- a/spec/controllers/questions_controller_spec.rb
+++ b/spec/controllers/questions_controller_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe QuestionsController, type: :controller do
         sign_in(another_student, scope: :user)
         post :upvote, params: { course_id: @lecture.course.id, lecture_id: @lecture.id, id: @question.id }, session: valid_session
         expected = ActiveModelSerializers::SerializableResource.new(
-            [@question, not_upvoted_question],
+          [@question, not_upvoted_question],
             each_serializer: QuestionSerializer,
             current_user: @lecturer)
         expect(Question.questions_for_lecture(@lecture, @lecturer).to_json).to eq(expected.to_json)

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Question, type: :model do
 
       it "should return list of a question" do
         expected = ActiveModelSerializers::SerializableResource.new(
-            [@question],
+          [@question],
             each_serializer: QuestionSerializer,
             current_user: @student)
         expect(Question.questions_for_lecture(@lecture, @student).to_json).to eq(expected.to_json)
@@ -51,7 +51,7 @@ RSpec.describe Question, type: :model do
       it "should return a time-sorted list of all questions" do
         question2 = FactoryBot.create(:question, author: @student, lecture: @lecture)
         expected = ActiveModelSerializers::SerializableResource.new(
-            [question2, @question],
+          [question2, @question],
             each_serializer: QuestionSerializer,
             current_user: @student)
         expect(Question.questions_for_lecture(@lecture, @student).to_json).to eq(expected.to_json)
@@ -62,7 +62,7 @@ RSpec.describe Question, type: :model do
         another_lecture.join_lecture(@student)
         FactoryBot.create(:question, author: @student, lecture: another_lecture)
         expected = ActiveModelSerializers::SerializableResource.new(
-            [@question],
+          [@question],
             each_serializer: QuestionSerializer,
             current_user: @student)
         expect(Question.questions_for_lecture(@lecture, @student).to_json).to eq(expected.to_json)

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -42,11 +42,18 @@ RSpec.describe Question, type: :model do
       end
 
       it "should return list of a question" do
-        expect(Question.questions_for_lecture(@lecture, @student).to_json).to eq([@question].to_json)
+        expected = ActiveModelSerializers::SerializableResource.new(
+            [@question],
+            each_serializer: QuestionSerializer,
+            current_user: @student)
+        expect(Question.questions_for_lecture(@lecture, @student).to_json).to eq(expected.to_json)
       end
       it "should return a time-sorted list of all questions" do
         question2 = FactoryBot.create(:question, author: @student, lecture: @lecture)
-        expected = [ question2, @question ]
+        expected = ActiveModelSerializers::SerializableResource.new(
+            [question2, @question],
+            each_serializer: QuestionSerializer,
+            current_user: @student)
         expect(Question.questions_for_lecture(@lecture, @student).to_json).to eq(expected.to_json)
       end
 
@@ -54,7 +61,10 @@ RSpec.describe Question, type: :model do
         another_lecture = FactoryBot.create(:lecture)
         another_lecture.join_lecture(@student)
         FactoryBot.create(:question, author: @student, lecture: another_lecture)
-        expected = [ @question ]
+        expected = ActiveModelSerializers::SerializableResource.new(
+            [@question],
+            each_serializer: QuestionSerializer,
+            current_user: @student)
         expect(Question.questions_for_lecture(@lecture, @student).to_json).to eq(expected.to_json)
       end
     end


### PR DESCRIPTION
# Resolves #230 

This PR adds the feature of question upvoting via lecture dashboard.

Acceptance Criteria:
- [x] Upvoting behaves as it would on the questions' tab
- [x] Upvoting adheres to soft real-time
- [x] Upvoted questions are outlined in the highlight color (same as for the selected filter)


Testing steps:
- create question and upvote it as student via the dashboard updates section

Steps needed for migration:
- none

---

Definition Of Done:
- [x] [Class-Diagram](https://www.lucidchart.com/invitations/accept/705a122b-58a9-4dfa-8b16-c936bc0a46bc) updated

