### PR TITLE
Feature/#202 feedback setting

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -3,6 +3,7 @@ class FeedbacksController < ApplicationController
   before_action :get_course
   before_action :get_lecture
   before_action :validate_joined_user_or_owner
+  before_action :validate_feedback_enabled
 
   def create
     @lecture = Lecture.find(params[:lecture_id])
@@ -43,6 +44,12 @@ class FeedbacksController < ApplicationController
       # return head :forbidden unless isJoinedStudent || isLectureOwner
       unless isJoinedStudent || isLectureOwner
         redirect_to course_path(@lecture.course), alert: "You are not a member of this lecture!"
+      end
+    end
+
+    def validate_feedback_enabled
+      unless @lecture.feedback_enabled
+        redirect_to course_lecture_path(@lecture.course, @lecture)
       end
     end
 end

--- a/app/controllers/lectures_controller.rb
+++ b/app/controllers/lectures_controller.rb
@@ -172,7 +172,7 @@ class LecturesController < ApplicationController
     end
 
     def lecture_params
-      params.require(:lecture).permit(:name, :enrollment_key, :status, :polls_enabled, :questions_enabled, :description, :date, :start_time, :end_time)
+      params.require(:lecture).permit(:name, :enrollment_key, :status, :polls_enabled, :questions_enabled, :description, :date, :start_time, :end_time, :feedback_enabled)
     end
 
     def require_lecturer

--- a/app/views/lectures/_form.html.erb
+++ b/app/views/lectures/_form.html.erb
@@ -59,6 +59,11 @@
     <%= form.label :polls_enabled, "Enable Polls", :class => "form-check-label" %>
   </div>
 
+  <div class="form-check">
+    <%= form.check_box :feedback_enabled, :disabled => lecture.ended?, :class => "form-check-input" %>
+    <%= form.label :feedback_enabled, "Enable Feedback", :class => "form-check-label" %>
+  </div>
+
   <div class="actions d-flex flex-row justify-content-between mt-2">
     <div>
       <%= yield(:action_left) %>

--- a/app/views/lectures/show.html.erb
+++ b/app/views/lectures/show.html.erb
@@ -63,34 +63,38 @@
   </div>
 
   <div class="container tab-pane fade" id="feedback" role="tabpanel" aria-labelledby="feedback-tab">
-    <% if @current_user.is_student %>
-      <%= form_with(model: [ @course, @lecture, @lecture.feedbacks.build ], :html => { :onsubmit => "handleSubmit()" }) do |form| %>
-        <% if @lecture.feedbacks.where(user_id: @current_user.id).present? %>
-          <p>
-            <%= form.label :content, "You submitted your feedback. Update it here."%>
-            <%= form.text_area(:content, :value => @lecture.feedbacks.where(user_id: @current_user.id).first.content, :class => "form-control") %>
-          </p>
-          <p>
-            <%= form.submit "Update", {class: "btn btn-primary", id: "feedback-submit"}  %>
-          </p>
-        <% else %>
-          <p>
-            <%= form.label :content, "Write your feedback here"%>
-            <%= form.text_area :content, {class: "form-control"} %>
-          </p>
-          <p>
-            <%= form.submit "Submit", {class: "btn btn-primary", id: "feedback-submit"} %>
-          </p>
+    <% if @lecture.feedback_enabled %>
+      <% if @current_user.is_student %>
+        <%= form_with(model: [ @course, @lecture, @lecture.feedbacks.build ], :html => { :onsubmit => "handleSubmit()" }) do |form| %>
+          <% if @lecture.feedbacks.where(user_id: @current_user.id).present? %>
+            <p>
+              <%= form.label :content, "You submitted your feedback. Update it here."%>
+              <%= form.text_area(:content, :value => @lecture.feedbacks.where(user_id: @current_user.id).first.content, :class => "form-control") %>
+            </p>
+            <p>
+              <%= form.submit "Update", {class: "btn btn-primary", id: "feedback-submit"}  %>
+            </p>
+          <% else %>
+            <p>
+              <%= form.label :content, "Write your feedback here"%>
+              <%= form.text_area :content, {class: "form-control"} %>
+            </p>
+            <p>
+              <%= form.submit "Submit", {class: "btn btn-primary", id: "feedback-submit"} %>
+            </p>
+          <% end %>
+          <div id="feedback-notification" style="display:none" class="alert alert-success" role="alert"> Feedback submitted</div>
         <% end %>
-        <div id="feedback-notification" style="display:none" class="alert alert-success" role="alert"> Feedback submitted</div>
-  <% end %>
-  <% else %>
-      <% @lecture.feedbacks.each do |feedback| %>
-        <p>
-          <strong>Feedback:</strong>
-          <%= feedback.content %>
-        </p>
+      <% else %>
+          <% @lecture.feedbacks.each do |feedback| %>
+            <p>
+              <strong>Feedback:</strong>
+              <%= feedback.content %>
+            </p>
+        <% end %>
       <% end %>
+    <% else %>
+      <h1> Feedback is not enabled. :(</h1>
     <% end %>
   </div>
 

--- a/db/migrate/20200124140445_add_feedback_enabled_to_lectures.rb
+++ b/db/migrate/20200124140445_add_feedback_enabled_to_lectures.rb
@@ -1,0 +1,5 @@
+class AddFeedbackEnabledToLectures < ActiveRecord::Migration[5.2]
+  def change
+    add_column :lectures, :feedback_enabled, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,7 +46,6 @@ ActiveRecord::Schema.define(version: 2020_01_24_140445) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
-    t.string "hash_id"
     t.index ["lecture_id"], name: "index_feedbacks_on_lecture_id"
     t.index ["user_id"], name: "index_feedbacks_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_20_184223) do
+ActiveRecord::Schema.define(version: 2020_01_24_140445) do
 
   create_table "answers", force: :cascade do |t|
     t.integer "student_id"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 2020_01_20_184223) do
     t.date "date"
     t.time "start_time"
     t.time "end_time"
+    t.boolean "feedback_enabled", default: true
     t.index ["course_id"], name: "index_lectures_on_course_id"
     t.index ["lecturer_id"], name: "index_lectures_on_lecturer_id"
   end
@@ -146,6 +147,7 @@ ActiveRecord::Schema.define(version: 2020_01_20_184223) do
     t.datetime "updated_at", null: false
     t.boolean "is_student", default: false, null: false
     t.integer "feedback_id"
+    t.string "hash_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["feedback_id"], name: "index_users_on_feedback_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_12_153848) do
+ActiveRecord::Schema.define(version: 2020_01_24_140445) do
 
   create_table "answers", force: :cascade do |t|
     t.integer "student_id"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 2020_01_12_153848) do
     t.date "date"
     t.time "start_time"
     t.time "end_time"
+    t.boolean "feedback_enabled", default: true
     t.index ["course_id"], name: "index_lectures_on_course_id"
     t.index ["lecturer_id"], name: "index_lectures_on_lecturer_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2020_01_24_140445) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.string "hash_id"
     t.index ["lecture_id"], name: "index_feedbacks_on_lecture_id"
     t.index ["user_id"], name: "index_feedbacks_on_user_id"
   end

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe FeedbacksController, type: :controller do
         get :create, params: { course_id: not_existing_course_id, lecture_id: not_existing_lecture_id }, session: valid_session
         expect(response).to redirect_to(root_path)
       end
+
+      it "reloads lecture view when feedback is given when not enabled anymore" do
+        @lecture.update(feedback_enabled: false)
+        get :create, params: { course_id: @lecture.course.id, lecture_id: @lecture }, session: valid_session
+        expect(response).to redirect_to(course_lecture_path(@lecture.course, @lecture))
+      end
     end
   end
 end

--- a/spec/views/lectures/edit.html.erb_spec.rb
+++ b/spec/views/lectures/edit.html.erb_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "lectures/edit", type: :view do
       assert_select "input[name=?]", "lecture[end_time]"
       assert_select "input[name=?]", "lecture[questions_enabled]"
       assert_select "input[name=?]", "lecture[polls_enabled]"
+      assert_select "input[name=?]", "lecture[feedback_enabled]"
       assert_select "textarea[name=?]", "lecture[description]"
     end
   end

--- a/spec/views/lectures/new.html.erb_spec.rb
+++ b/spec/views/lectures/new.html.erb_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe "lectures/new", type: :view do
 
       assert_select "input[name=?]", "lecture[polls_enabled]"
 
+      assert_select "input[name=?]", "lecture[feedback_enabled]"
+
       assert_select "textarea[name=?]", "lecture[description]"
     end
   end

--- a/spec/views/lectures/show.html.erb_spec.rb
+++ b/spec/views/lectures/show.html.erb_spec.rb
@@ -74,11 +74,18 @@ RSpec.describe "lectures/show", type: :view do
       expect(rendered).to have_text("Questions are not enabled.")
     end
 
-    it "does not show notice pages on disabled questions/polls when questions are enabled" do
+    it "shows notice page on feedback tab when feedback is disabled" do
+      @lecture.update(feedback_enabled: false)
       render
-      assert_select "a", "Questions"
+      assert_select "a", "Feedback"
+      expect(rendered).to have_text("Feedback is not enabled.")
+    end
+
+    it "does not show notice pages on disabled questions/polls/feedback when questions are enabled" do
+      render
       expect(rendered).to_not have_text("Questions are not enabled.")
       expect(rendered).to_not have_text("Polls are not enabled.")
+      expect(rendered).to_not have_text("Feedback is not enabled.")
     end
 
     it "shows list of participating students in enrollment key tab" do


### PR DESCRIPTION
# Resolves #202 

This PR introduces the feature of dis-/enabling of the feedback function.

Acceptance Criteria:

- [ ]     When creating a lecture a checkbox titled "Enable Feedback" (or comparable) is displayed
- [ ]     The same checkbox is displayed when editing settings after creating the lecture
- [ ]     If the checkbox is checked the feature is enabled nothing is changed from the current implementation
- [ ]     If the checkbox is unchecked I see the string "feedback is disabled for this lecture" (or comparable) when opening the feedback tab
- [ ]     If the checkbox is unchecked my students see the string "feedback is disabled for this lecture" (or comparable) when opening the feedback fab
- [ ]     If the

 checkbox is unchecked students can not create feedback


Steps needed for migration:
- run `rails db:migrate`

---

Definition Of Done:
- [ ] [Class-Diagram](https://www.lucidchart.com/invitations/accept/705a122b-58a9-4dfa-8b16-c936bc0a46bc) updated

