### PR TITLE
Show edit/review buttons for active lectures too

### DIFF
--- a/app/assets/stylesheets/lecture_comprehension.scss
+++ b/app/assets/stylesheets/lecture_comprehension.scss
@@ -127,3 +127,10 @@
     }
   }
 }
+
+@media(max-width: 767px) {
+  .comprehensionItem {
+    float: none !important;
+    width: 100% !important;
+  }
+}

--- a/app/views/courses/_table_only_running.erb
+++ b/app/views/courses/_table_only_running.erb
@@ -44,7 +44,7 @@
                 <%= button_to 'Join', join_lecture_path(:course_id => @course.id, :id => lecture.id),method: :post, class:"btn btn-primary" %>
               <% end %>
             <% else %>
-              <% if lecture.status == "running" %>
+              <% if lecture.status == "running" || lecture.status == "active" %>
                 <%= link_to 'Edit', edit_course_lecture_path(:course_id => course.id, :id => lecture.id), {class:"btn btn-outline-secondary"} %>
                 <%= link_to 'View', course_lecture_path(:course_id => course.id, :id => lecture.id), {class:"btn btn-primary"} %>
               <% end %>


### PR DESCRIPTION
# Resolves #number

This PR adds the feature of edit/review buttons for active lectures.

Acceptance Criteria:
- [x] edit/view button for active lectures


Testing steps:
- create an active lecture and look for the buttons

Steps needed for migration:
- none

---

Definition Of Done:
- [x] [Class-Diagram](https://www.lucidchart.com/invitations/accept/705a122b-58a9-4dfa-8b16-c936bc0a46bc) updated

