### PR TITLE
Feature/#241 rename leave course button

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -49,7 +49,7 @@
 
 <div class="d-flex justify-content-center">
   <% if @current_user.is_student %>
-    <%= link_to "Leave", leave_course_path(id: @course.id), method: :post, class:"btn btn-primary" %> |
+    <%= link_to "Unenroll", leave_course_path(id: @course.id), method: :post, class:"btn btn-primary" %> |
   <% end %>
 
   <% if !@current_user.is_student %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -76,7 +76,7 @@
             <tr>
               <td><%= course.name %></td>
               <td><%= button_to "View", course_path(id: course.id), :method => "get", class:"btn btn-primary" %></td>
-              <td><%= link_to "Leave", leave_course_path(id: course.id), method: :post, class:"btn btn-primary" %></td>
+              <td><%= link_to "Unenroll", leave_course_path(id: course.id), method: :post, class:"btn btn-primary" %></td>
             </tr>
           <% end %>
         </table>

--- a/spec/views/courses/show.html.erb_spec.rb
+++ b/spec/views/courses/show.html.erb_spec.rb
@@ -45,6 +45,11 @@ RSpec.describe "courses/show", type: :view do
       assert_select "form input", count: 1
       assert_select "form", count: 1
     end
+
+    it "shows an 'Unenroll' button" do
+      render
+      expect(rendered).to have_link("Unenroll")
+    end
   end
 
   def login_student(user = FactoryBot.create(:user, :student))

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -64,6 +64,12 @@ RSpec.describe "home/index", type: :view do
       # it's 2 because of the courses button
       expect(page).to have_css("input", count: 2)
     end
+
+    it "shows an 'Unenroll' button" do
+      # because a joined course is displayed
+      visit root_path
+      expect(page).to have_link("Unenroll")
+    end
   end
 
   def login_student(user = FactoryBot.create(:user, :student))


### PR DESCRIPTION
# Resolves #241 

This PR changes the naming of buttons for leaving a course from "Leave" to "Unenroll".

Acceptance Criteria:
- [ ] The Button "Leave Course" in the course overview is now named "Unenroll"


Testing steps:
- Login as student
- Join a course (create one as lecturer if not done already)
- Homepage and Course overview show "Unenroll" instead of "Leave"

Steps needed for migration:
- none

---

Definition Of Done:
- [x] [Class-Diagram](https://www.lucidchart.com/invitations/accept/705a122b-58a9-4dfa-8b16-c936bc0a46bc) updated

