### PR TITLE
Redirect back to course overview instead of detail view after editing a lecture

### DIFF
--- a/app/views/lectures/edit.html.erb
+++ b/app/views/lectures/edit.html.erb
@@ -4,7 +4,7 @@
   <%= link_to 'Delete', course_lecture_path(course_id:@lecture.course.id, id: @lecture.id), method: :delete, data: { confirm: 'Are you sure?' }, :class => "btn btn-outline-secondary" %>
 <% end %>
 <% content_for :action_right do %>
-  <%= link_to (fa_icon 'arrow-left', text: 'Back'), course_lecture_path(course_id:@lecture.course.id, id: @lecture.id), class: "btn btn-outline-primary" %>
+  <%= link_to (fa_icon 'arrow-left', text: 'Back'), course_path(id:@lecture.course.id), class: "btn btn-outline-primary" %>
 <% end %>
 <%= render 'form', lecture: @lecture, render_enrolment_key: true do %>
 <% end %>

--- a/spec/views/lectures/edit.html.erb_spec.rb
+++ b/spec/views/lectures/edit.html.erb_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "lectures/edit", type: :view do
 
   it "should have a \"back\" button which redirects to the course overview." do
     render
-    assert_select "[href =?]", course_path(id:@course.id))
+    assert_select "[href =?]", course_path(id: @course.id)
   end
 
   it "renders a delete button" do

--- a/spec/views/lectures/edit.html.erb_spec.rb
+++ b/spec/views/lectures/edit.html.erb_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe "lectures/edit", type: :view do
     end
   end
 
+  it "should have a \"back\" button which redirects to the course overview." do
+    render
+    assert_select "[href =?]", course_path(id:@course.id))
+  end
+
   it "renders a delete button" do
     render
 


### PR DESCRIPTION
# Resolves #258 


