### PR TITLE
Add check whether database exists

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,6 @@
-require_relative 'boot'
+require_relative "boot"
 
-require 'rails/all'
+require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -8,6 +8,13 @@ Bundler.require(*Rails.groups)
 
 module LecturePortal
   class Application < Rails::Application
+    def database_exists?
+      ActiveRecord::Base.connection
+    rescue ActiveRecord::NoDatabaseError
+      false
+    else
+      true
+    end
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
@@ -20,18 +27,18 @@ module LecturePortal
     # the framework and any gems in your application.
 
     config.after_initialize do
-      unless defined?(Rails::Console) || Rails.env.test? || File.split($0).last == 'rake' then
+      unless defined?(Rails::Console) || Rails.env.test? || File.split($0).last == "rake" || !database_exists? then
         scheduler = Rufus::Scheduler.singleton
 
         # Schedule a check for aging of comprehension stamps
-        scheduler.every '30s' do
+        scheduler.every "30s" do
           ActiveRecord::Base.connection_pool.with_connection do
             Lecture.eliminate_comprehension_stamps
           end
         end
 
         # Schedule a check for lecture cyclus
-        scheduler.every '1m' do
+        scheduler.every "1m" do
           ActiveRecord::Base.connection_pool.with_connection do
             Lecture.handle_activations
           end


### PR DESCRIPTION
# Resolves #304

This PR adds checking whether a database exists in the config.

Acceptance Criteria:
- [ ] If the database does not exist it adds a scheduler singleton.


Testing steps:
- Start the application with the new config.

---

Definition Of Done:
- [ ] [Class-Diagram](https://www.lucidchart.com/invitations/accept/705a122b-58a9-4dfa-8b16-c936bc0a46bc) updated

