### PR TITLE
Fix bug of dejoining students after status change

### DIFF
--- a/app/controllers/lectures_controller.rb
+++ b/app/controllers/lectures_controller.rb
@@ -53,7 +53,7 @@ class LecturesController < ApplicationController
 
   # PATCH/PUT courses/:course_id/lectures/1
   def update
-    if !@lecture.enrollment_key_present? && lecture_params[:enrollment_key]
+    if !@lecture.enrollment_key_present? && !lecture_params[:enrollment_key].empty?
       @lecture.participating_students.each do | student |
         @lecture.leave_lecture(student)
       end


### PR DESCRIPTION
# Resolves #318 

This PR fixes that students are kicked out of lecture after an update.

Testing steps:
- create a lecture
- let the student join the lecture
- change the status by changing the timeslot
- watch students not being kicked out :)

---

Definition Of Done:
- [ ] [Class-Diagram](https://www.lucidchart.com/invitations/accept/705a122b-58a9-4dfa-8b16-c936bc0a46bc) updated

