### PR TITLE
Restore participants icon

### DIFF
--- a/app/javascript/components/ParticipantsCount.tsx
+++ b/app/javascript/components/ParticipantsCount.tsx
@@ -13,7 +13,7 @@ const ParticipantsCount: React.FunctionComponent<{}> = observer(() => {
     const { poll_participants_count } = useInjectPollOptions(mapStore);
     return (
         <div id="number-of-participants">
-            <FontAwesomeIcon icon={faUserAlt} inverse className="user-icon" />
+            <FontAwesomeIcon icon={faUserAlt} inverse className={"user-icon"} />
             {poll_participants_count.numberOfParticipants} of {poll_participants_count.numberOfLectureUsers} participants
          </div>
     );


### PR DESCRIPTION
The icon for the participants count disappeared, this PR adds the braces again so the syntax is restored
