### PR TITLE
Delete double view button

### DIFF
--- a/app/views/polls/_lecturer_table.html.erb
+++ b/app/views/polls/_lecturer_table.html.erb
@@ -21,7 +21,6 @@
             <%= link_to 'Start', stop_start_course_lecture_poll_path(poll.lecture.course, poll.lecture, poll), {class: "btn btn-primary"} %>
           <% else %>
             <%= link_to 'View', course_lecture_poll_path(poll.lecture.course, poll.lecture, poll), {class: "btn btn-primary"} %>
-            <%= link_to 'View', course_lecture_poll_path(poll.lecture.course, poll.lecture, poll), {class: "btn btn-primary"} %>
           <% end %>
         <% end %>
       </td>


### PR DESCRIPTION
When viewing the available polls as a lecturer, there were two "view" buttons.
This MR removes one of them.
![image](https://user-images.githubusercontent.com/33000454/73562345-392a2f00-445b-11ea-9439-5a3f1fbbc4d2.png)

