### PR TITLE
Delete unnecessary table rows

### DIFF
--- a/app/views/polls/_lecturer_table.html.erb
+++ b/app/views/polls/_lecturer_table.html.erb
@@ -4,8 +4,6 @@
     <th scope="col">Title</th>
     <th scope="col">Active</th>
     <th scope="col"></th>
-    <th scope="col"></th>
-    <th scope="col"></th>
   </tr>
   </thead>
 

--- a/app/views/polls/_student_table.html.erb
+++ b/app/views/polls/_student_table.html.erb
@@ -4,7 +4,6 @@
     <th scope="col">Title</th>
     <th scope="col">Active</th>
     <th scope="col"></th>
-    <th scope="col"></th>
   </tr>
   </thead>
 


### PR DESCRIPTION
A table row for a poll doesn't take up the whole width (see picture), this MR deletes unncessary table rows to fix this.
![image](https://user-images.githubusercontent.com/33000454/73563219-1dc02380-445d-11ea-96f0-a4fd92155e88.png)
