### PR TITLE
Feature/#379 seperate page to diplay joined students

### DIFF
--- a/app/controllers/lectures_controller.rb
+++ b/app/controllers/lectures_controller.rb
@@ -84,6 +84,11 @@ class LecturesController < ApplicationController
     end
   end
 
+  def studentList
+    @hide_navbar = true
+    render :studentList
+  end
+
   def join_lecture
     if params[:lecture].present?
       key = params[:lecture][:enrollment_key]

--- a/app/views/lectures/_tabbar.html.erb
+++ b/app/views/lectures/_tabbar.html.erb
@@ -19,6 +19,9 @@
         </li>
       <% end %>
       <li class="nav-item">
+        <a class="nav-link" id="studentList-tab" data-toggle="tab" href="#studentList" role="tab" aria-controls="studentList" aria-selected="false">Student List</a>
+      </li>
+      <li class="nav-item">
         <a class="nav-link" id="settings-tab" data-toggle="tab" href="#settings" role="tab" aria-controls="settings" aria-selected="false">Settings</a>
       </li>
     <% end %>

--- a/app/views/lectures/show.html.erb
+++ b/app/views/lectures/show.html.erb
@@ -118,14 +118,13 @@
           <%= raw @qr_code.as_svg(offset: 0, color: '000', shape_rendering: 'crispEdges', module_size: 10, standalone: true) %>
         </div>
         <% end %>
-        <p class="h3 padded-text"> Students </p>
-          <ol>
-            <% for student in @lecture.participating_students%>
-              <li><%= student.email %></li>
-            <% end %>
-          </ol>
       </div>
     <% end %>
+
+    <div class="container tab-pane fade" id="studentList" role="tabpanel" aria-labelledby="studentList-tab">
+      <iframe class="polls-iframe" src="<%= studentList_path(@course, @lecture) %>"></iframe>
+    </div>
+
     <div class="container tab-pane fade" id="settings" role="tabpanel" aria-labelledby="settings-tab">
       <%= render 'form', lecture: @lecture %>
     </div>

--- a/app/views/lectures/studentList.html.erb
+++ b/app/views/lectures/studentList.html.erb
@@ -1,0 +1,15 @@
+<p class="h1 padded-text"> Students </p>
+<ol>
+    <% for student in @lecture.participating_students%>
+    <li><%= student.email %></li>
+    <% end %>
+</ol>
+
+<script lang="js">
+    function main() {
+        setTimeout(function () {
+          window.location.reload(true);
+        }, 3000);
+    };
+    main();
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   get "/courses/:course_id/lectures/current", to: "lectures#current", as: "current_lectures"
+  get "/courses/:course_id/lectures/:lecture_id/studentList", to: "lectures#studentList", as: "studentList"
   get "/ical/:hash_id", to: "ical#show", as: "ical"
   post "/courses/:course_id/lectures/join_lecture", to: "lectures#join_lecture", as: "join_lecture"
   get "/courses/:course_id/lectures/:lecture_id/enroll", to: "lectures#join_lecture_with_url", as: "join_lecture_with_url"

--- a/spec/views/lectures/show.html.erb_spec.rb
+++ b/spec/views/lectures/show.html.erb_spec.rb
@@ -43,6 +43,13 @@ RSpec.describe "lectures/show", type: :view do
       expect(rendered).to have_css("#enrollmentKey-tab")
     end
 
+    it "renders student list tab" do
+      render
+      assert_select "a", "Student List"
+      expect(rendered).to have_content("Student List")
+      expect(rendered).to have_css("#studentList-tab")
+    end
+
     it "renders enrollment qr code if enrollment key is present" do
       @qr_code = RQRCode::QRCode.new("http://some-random.url/that/is/not/tested")
       render
@@ -86,13 +93,6 @@ RSpec.describe "lectures/show", type: :view do
       expect(rendered).to_not have_text("Questions are not enabled.")
       expect(rendered).to_not have_text("Polls are not enabled.")
       expect(rendered).to_not have_text("Feedback is not enabled.")
-    end
-
-    it "shows list of participating students in enrollment key tab" do
-      @lecture.join_lecture(FactoryBot.create(:user, :student, email: "student@mail.com"))
-      render
-      assert_select "a", "Enrollment Key"
-      expect(rendered).to have_text("student@mail.com")
     end
 
     it "can change title in settings tab" do
@@ -143,6 +143,12 @@ RSpec.describe "lectures/show", type: :view do
       render
       expect(rendered).not_to have_content("Enrollment Key")
       expect(rendered).not_to have_css("#enrollmentKey-tab")
+    end
+
+    it "renders no student list tab" do
+      render
+      expect(rendered).not_to have_content("Student List")
+      expect(rendered).not_to have_css("#studentList-tab")
     end
 
     it "renders no settings tab" do

--- a/spec/views/lectures/studentList.html.erb_spec.rb
+++ b/spec/views/lectures/studentList.html.erb_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe "lectures/studentList", type: :view do
+  include Devise::TestHelpers
+  let(:valid_session) { {} }
+  before(:each) do
+    @course = FactoryBot.create(:course)
+    @lecture = assign(:lecture, Lecture.create!(
+                                  name: "Name",
+                                  enrollment_key: "Enrollment Key",
+                                  status: "running",
+                                  lecturer: FactoryBot.create(:user, :lecturer),
+                                  course: @course,
+                                  date: Date.today,
+                                  start_time: DateTime.now,
+                                  end_time: DateTime.now + 20.minutes
+    ))
+  end
+
+  describe "as a lecturer" do
+    before(:each) do
+      @current_user = @lecture.lecturer
+      sign_in @lecture.lecturer
+    end
+
+    it "shows list of participating students" do
+      user = FactoryBot.create(:user, :student, email: "student@mail.com")
+      @course.join_course(user)
+      @lecture.join_lecture(user)
+      render
+      expect(rendered).to have_text("student@mail.com")
+    end
+  end
+end


### PR DESCRIPTION
# Resolves #379 

- A new tab exists called Student List (sl)
- If I'm on the sl I can still see the navigator to the lecture
- The sl contains a list of all students that have joined the lecture
- the sl contains a descriptive title
-- Every time the sl view is opened the data displayed is as up to date as possible (reload every 3 seconds)


