### PR TITLE
Bugfix/#385 redirect lecturer to course overview after lecture creation

### DIFF
--- a/app/controllers/lectures_controller.rb
+++ b/app/controllers/lectures_controller.rb
@@ -48,7 +48,7 @@ class LecturesController < ApplicationController
     @lecture = @course.lectures.build(lecture_params)
     @lecture.lecturer = current_user
     if @lecture.save
-      redirect_to course_lecture_path(@course, @lecture), notice: "Lecture was successfully created."
+      redirect_to course_path(@course), notice: "Lecture was successfully created."
     else
       render :new
     end

--- a/spec/controllers/lectures_controller_spec.rb
+++ b/spec/controllers/lectures_controller_spec.rb
@@ -159,10 +159,10 @@ RSpec.describe LecturesController, type: :controller do
         }.to change(Lecture, :count).by(0)
       end
 
-      it "redirects to the lecture dashboard", :logged_lecturer do
+      it "redirects to the course overview", :logged_lecturer do
         course = FactoryBot.create(:course, creator: @lecturer)
         post :create, params: { course_id: (course.id), lecture: valid_attributes }, session: valid_session
-        expect(response).to redirect_to(course_lecture_path(course_id: course.id, id: Lecture.find_by(course_id: course.id).id))
+        expect(response).to redirect_to(course_path(id: course.id))
       end
     end
 


### PR DESCRIPTION
# Resolves #385 

This PR makes it so that a lecturer is redirected to the overview of the corresponding course after creating a lecture instead of the lecture view.

Acceptance Criteria:
- None


Testing steps:
- log in as lecturer
- create course or view existing one
- create new lecture
- be redirected to course overview

Steps needed for migration:
- None

---

Definition Of Done:
- [x] [Class-Diagram](https://www.lucidchart.com/invitations/accept/705a122b-58a9-4dfa-8b16-c936bc0a46bc) updated

